### PR TITLE
Added panic handler middleware; returning correct errors in `/api/days/brief`

### DIFF
--- a/src/common.go
+++ b/src/common.go
@@ -1,12 +1,10 @@
 package main
 
-import "log"
-
 //Panics if `err` is not `nil`
 //
 // @param err Error to be checked for equality to `nil`
 func panicIfError(err error) {
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 }

--- a/src/middleware.go
+++ b/src/middleware.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 )
 
+// APIPanicHandlerMiddleware is an HTTP middleware, handling panic and sending the error json as a response in case of
+// errors
 func APIPanicHandlerMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
@@ -29,6 +31,8 @@ func APIPanicHandlerMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// UIPanicHandlerMiddleware is an HTTP middleware, handling panic and sending the user-readable error page as a response
+// in case of errors
 func UIPanicHandlerMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {

--- a/src/middleware.go
+++ b/src/middleware.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func APIPanicHandlerMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if err := recover(); err != nil {
+				log.Println(err)
+
+				js, err := json.Marshal(map[string]interface{}{"ok": false, "error": fmt.Sprint(err)})
+				if err != nil {
+					log.Println(err)
+					http.Error(w, "{\"ok\":false,\"error\":\"unknown\"}", http.StatusInternalServerError)
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				http.Error(w, string(js), http.StatusInternalServerError)
+			}
+		}()
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func UIPanicHandlerMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if err := recover(); err != nil {
+				log.Println(err)
+
+				w.WriteHeader(http.StatusInternalServerError)
+				if err := tmpl.ExecuteTemplate(w, "500", fmt.Sprint(err)); err != nil {
+					log.Println(err)
+
+					// I don't think we need to handle the following error, because what can we do if it occurs?
+					_, _ = w.Write([]byte("It failed :("))
+				}
+			}
+		}()
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/src/templates/500.html
+++ b/src/templates/500.html
@@ -1,0 +1,12 @@
+{{define "500"}}
+	<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title>500</title>
+	</head>
+
+	<body>
+	<h1>500</h1>
+	</body>
+	</html>
+{{end}}


### PR DESCRIPTION
This PR introduces middleware, recovering from panic and returning `500 Internal Server Error` (with a template file for UI and the format described in the docs for API) and fixes #9